### PR TITLE
Fix autoload to ignore older emacs versions

### DIFF
--- a/birds-of-paradise-plus-theme.el
+++ b/birds-of-paradise-plus-theme.el
@@ -194,7 +194,8 @@
 
 
 ;;;###autoload
-(when load-file-name
+(and load-file-name
+  (boundp 'custom-theme-load-path)
   (add-to-list 'custom-theme-load-path
                (file-name-as-directory (file-name-directory load-file-name))))
 


### PR DESCRIPTION
Fix autoload to ignore older emacs versions without custom themes.
